### PR TITLE
Test(s) of suggested change for app_limited and datagrams

### DIFF
--- a/src/h3/mod.rs
+++ b/src/h3/mod.rs
@@ -812,7 +812,7 @@ impl Connection {
         b.put_varint(flow_id)?;
         b.put_bytes(buf)?;
 
-        conn.dgram_queue.push_writable(&d)?;
+        conn.dgram_queue.writable_mut().push(&d)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2920,6 +2920,12 @@ impl Connection {
 
         self.dgram_queue.writable_mut().push(buf)?;
 
+        if self.dgram_queue.writable().pending_bytes() >
+            self.recovery.cwnd_available()
+        {
+            self.recovery.update_app_limited(false);
+        }
+
         Ok(())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6434,6 +6434,66 @@ mod tests {
         // app_limited should be false because we can't send more by cwnd.
         assert_eq!(pipe.server.recovery.app_limited(), false);
     }
+
+    #[test]
+    fn dgram_send_app_limited() {
+        let mut buf = [0; 65535];
+        let send_buf = [0xcf; 1000];
+
+        let mut config = Config::new(crate::PROTOCOL_VERSION).unwrap();
+        config.load_cert_chain_from_pem_file("examples/cert.crt").unwrap();
+        config.load_priv_key_from_pem_file("examples/cert.key").unwrap();
+        config.set_application_protos(b"\x06proto1\x06proto2").unwrap();
+        config.set_initial_max_data(30);
+        config.set_initial_max_stream_data_bidi_local(15);
+        config.set_initial_max_stream_data_bidi_remote(15);
+        config.set_initial_max_stream_data_uni(10);
+        config.set_initial_max_streams_bidi(3);
+        config.set_initial_max_streams_uni(3);
+        config.set_max_datagram_frame_size(65535);
+        config.set_dgram_recv_queue_len(1000);
+        config.set_dgram_send_queue_len(1000);
+        config.set_max_packet_size(1200);
+        config.verify_peer(false);
+
+        let mut pipe = testing::Pipe::with_config(&mut config).unwrap();
+
+        assert_eq!(pipe.handshake(&mut buf), Ok(()));
+        assert_eq!(pipe.advance(&mut buf), Ok(()));
+
+        for _ in 0..1000 {
+            assert_eq!(pipe.client.dgram_send(&send_buf), Ok(()));
+        }
+
+        assert!(!pipe.client.recovery.app_limited());
+        assert_eq!(pipe.client.dgram_queue.writable().pending_bytes(), 1_000_000);
+
+        println!("After send/recv 1 : queued={} app_limited={}",
+            pipe.client.dgram_queue.writable().pending_bytes(),
+            pipe.client.recovery.app_limited());
+
+        let len = pipe.client.send(&mut buf).unwrap();
+
+        println!("After send/recv 2 : queued={} app_limited={}",
+            pipe.client.dgram_queue.writable().pending_bytes(),
+            pipe.client.recovery.app_limited());
+
+        assert_ne!(pipe.client.dgram_queue.writable().pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_queue.writable().pending_bytes(), 1_000_000);
+        assert!(!pipe.client.recovery.app_limited());
+
+        testing::recv_send(&mut pipe.client, &mut buf, len).unwrap();
+        testing::recv_send(&mut pipe.server, &mut buf, len).unwrap();
+
+        println!("After send/recv 3 : queued={} app_limited={}",
+            pipe.client.dgram_queue.writable().pending_bytes(),
+            pipe.client.recovery.app_limited());
+
+        assert_ne!(pipe.client.dgram_queue.writable().pending_bytes(), 0);
+        assert_ne!(pipe.client.dgram_queue.writable().pending_bytes(), 1_000_000);
+
+        assert!(!pipe.client.recovery.app_limited());
+    }
 }
 
 pub use crate::packet::Header;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2438,6 +2438,12 @@ impl Connection {
 
         self.sent_count += 1;
 
+        if self.dgram_queue.writable().pending_bytes() >
+            self.recovery.cwnd_available()
+        {
+            self.recovery.update_app_limited(false);
+        }
+
         // On the client, drop initial state after sending an Handshake packet.
         if !self.is_server && hdr.ty == packet::Type::Handshake {
             self.drop_epoch_state(packet::EPOCH_INITIAL);


### PR DESCRIPTION
In https://github.com/LPardue/quiche/pull/7 junhochoi suggested some changes and this tracks those changes.

I started from a new branch (https://github.com/xanathar/quiche/tree/lpdgalt-pr7-junho-test-base) which has all the changes for datagrams, plus change 490 cherry-picked on top of it (it was not part of the datagrams branch yet), and the changes involving data_pending/app_limited manually rolled back.

On top I went on with the 4 commits in this PR:

1. Refactored data queue -> the data queue was getting more complex, so this keeps it simpler and I actually like the idea; feedback is welcome

2. Added failing dgram_send_app_limited test -> as it said, I removed the old code, and added this test to check for app_limited.

3. Added update app_limited on `dgram_send` -> this adds a check to `dgram_send` which sets `recovery.app_limited` to `false`. At this point, the unit test still fails.

4. Added the same snippet of code at the end of `Connection::send`. The test now runs green.

I think the code is a lot cleaner than before, but it seems the check in `Connection::send` is still needed.