### PR TITLE
Activable feature to ignore Congestion Control on datagram frames.

### DIFF
--- a/include/quiche.h
+++ b/include/quiche.h
@@ -192,6 +192,9 @@ void quiche_config_set_dgram_recv_max_queue_len(quiche_config *config, size_t v)
 // Sets the maximum length of the DATAGRAM send queue.
 void quiche_config_set_dgram_send_max_queue_len(quiche_config *config, size_t v);
 
+// Configure whether DATAGRAMS should ignore congestion control or not.
+void quiche_config_enable_dgram_ignore_cc(quiche_config *config, bool v);
+
 // Frees the config object.
 void quiche_config_free(quiche_config *config);
 

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -252,6 +252,15 @@ pub extern fn quiche_config_set_dgram_send_max_queue_len(
     config.set_dgram_send_max_queue_len(v);
 }
 
+
+#[no_mangle]
+#[cfg(feature = "quic-dgram")]
+pub extern fn quiche_config_enable_dgram_ignore_cc(
+    config: &mut Config, v: bool,
+) {
+    config.enable_dgram_ignore_cc(v)
+}
+
 #[no_mangle]
 pub extern fn quiche_config_enable_hystart(config: &mut Config, v: bool) {
     config.enable_hystart(v);


### PR DESCRIPTION
# Background
We want an activatable feature which allows datagram frames ignoring congestion control.

# PR Description
* Added an activatable "switch" in the connection configuration. 
* When the flag is enabled (the feature is active):
  - Packets containg datagram frames are not bounded by *CWND* (i.e., window congestion control).
  - Datagram frames are marked as *NOT ack eliciting* and *NOT in flight*.
* The default value is `false`. I.e., this feature is disabled.